### PR TITLE
refactor(clear-pinned-messages): use Promise.all

### DIFF
--- a/scripts/clear-pinned-messages.ts
+++ b/scripts/clear-pinned-messages.ts
@@ -19,20 +19,13 @@ const main = async () => {
 		.map((message) => `https://discord.com/channels/${process.env.GUILD_ID ?? message.guild_id}/${message.channel_id}/${message.id}`)
 		.join('\n\t\t');
 
-	const promises = sortedOriginChannelPins.map((message) =>
-		rest.delete<RESTDeleteAPIChannelMessageResult>(`/channels/${process.env.ORIGIN_CHANNEL_ID}/pins/${message.id}`)
+	await Promise.all(
+		sortedOriginChannelPins.map((message) =>
+			rest
+				.delete<RESTDeleteAPIChannelMessageResult>(`/channels/${process.env.ORIGIN_CHANNEL_ID}/pins/${message.id}`)
+				.catch((error) => console.log(`There was an error unpinning the message ${message.id}. ${error}`))
+		)
 	);
-
-	const settled = await Promise.allSettled(promises);
-
-	for (let i = 0; i < settled.length; i++) {
-		const promise = settled[i];
-		const message = sortedOriginChannelPins[i];
-
-		if (promise.status === 'rejected') {
-			console.log(`There was an error unpinning the message ${message.id}. ${promise.reason}`);
-		}
-	}
 
 	console.log(stripIndent`
 		List of urls:

--- a/scripts/clear-pinned-messages.ts
+++ b/scripts/clear-pinned-messages.ts
@@ -18,14 +18,22 @@ const main = async () => {
 	const sortedOriginChannelPinsURLS = sortedOriginChannelPins
 		.map((message) => `https://discord.com/channels/${process.env.GUILD_ID ?? message.guild_id}/${message.channel_id}/${message.id}`)
 		.join('\n\t\t');
-	for (const message of sortedOriginChannelPins) {
-		try {
-			await rest.delete<RESTDeleteAPIChannelMessageResult>(`/channels/${process.env.ORIGIN_CHANNEL_ID}/pins/${message.id}`);
-		} catch (e) {
-			console.log(`There was an error unpinning the message ${message.id}. ${e}`);
-			continue;
+
+	const promises: Promise<RESTDeleteAPIChannelMessageResult>[] = sortedOriginChannelPins.map((message) =>
+		rest.delete<RESTDeleteAPIChannelMessageResult>(`/channels/${process.env.ORIGIN_CHANNEL_ID}/pins/${message.id}`)
+	);
+
+	const settled = await Promise.allSettled(promises);
+
+	for (let i = 0; i < settled.length; i++) {
+		const promise = settled[i];
+		const message = sortedOriginChannelPins[i];
+
+		if (promise.status === 'rejected') {
+			console.log(`There was an error unpinning the message ${message.id}. ${promise.reason}`);
 		}
 	}
+
 	console.log(stripIndent`
 		List of urls:
 		${sortedOriginChannelPinsURLS}

--- a/scripts/clear-pinned-messages.ts
+++ b/scripts/clear-pinned-messages.ts
@@ -19,7 +19,7 @@ const main = async () => {
 		.map((message) => `https://discord.com/channels/${process.env.GUILD_ID ?? message.guild_id}/${message.channel_id}/${message.id}`)
 		.join('\n\t\t');
 
-	const promises: Promise<RESTDeleteAPIChannelMessageResult>[] = sortedOriginChannelPins.map((message) =>
+	const promises = sortedOriginChannelPins.map((message) =>
 		rest.delete<RESTDeleteAPIChannelMessageResult>(`/channels/${process.env.ORIGIN_CHANNEL_ID}/pins/${message.id}`)
 	);
 


### PR DESCRIPTION
This PR refactors the `clear-pinned-messages` to prevent using `await` in a `for..of` loop, by instead mapping the array of message IDs to an array of promises that indicate when the `DELETE` request has completed. This approach is much faster - especially on rate limits that aren't tight.

This could theoretically also be accomplished with `send-pinned-messages`, but it would mean losing the order, and as such, is not practical.